### PR TITLE
Solve Super Bomberman 5 freeze at startup

### DIFF
--- a/src/apu.c
+++ b/src/apu.c
@@ -1089,7 +1089,7 @@ static void dsp_run( int clocks_remain )
             break;
          case 25:
          v0 = (dsp_voice_t*)&dsp_m.voices[0];
-         v1 = (dsp_voice_t*)(v0 + 6);
+         v1 = (dsp_voice_t*)(v0 + 7);
          dsp_voice_V3b(v0);
          dsp_voice_V9(v1);
          dsp_echo_25();


### PR DESCRIPTION
Since commit 94551450681fc94dc359607c469ab18f8cbcfa1c the rom Super Bomberman 5 freezes at startup screen.
It's because there is a mistake in the commit 94551450681fc94dc359607c469ab18f8cbcfa1c.
The case 25 has been wrongly converted.
A delta of 6 has been used instead of 7.
With this patch, the rom Super Bomberman 5 doesn't freeze anymore.