### PR TITLE
Android makefile fixes,Dont try to overclock superfx every frame

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -1,5 +1,3 @@
-HAVE_GRIFFIN := 1
-
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -8,7 +6,23 @@ LOCAL_MODULE    := retro
 
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM
+#LOCAL_ARM_MODE := arm
+
+#enable/disable optimization
+ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
+V7PLUSOPTIMIZATION ?= 1
+endif
+
+#armv7+ optimizations
+ifeq ($(V7PLUSOPTIMIZATION),1)
+#we dont need LOCAL_ARM_MODE := arm because armv7a has thumb2 that has varible length instructions
+LOCAL_ARM_MODE := thumb
+LOCAL_ARM_NEON := true
+else
 LOCAL_ARM_MODE := arm
+endif
+
+
 endif
 
 ifeq ($(TARGET_ARCH),x86)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -6,23 +6,27 @@ LOCAL_MODULE    := retro
 
 ifeq ($(TARGET_ARCH),arm)
 LOCAL_CFLAGS += -DANDROID_ARM
-#LOCAL_ARM_MODE := arm
+
+#arm speedups
+#default to thumb because its smaller and more can fit in the cpu cache
+LOCAL_ARM_MODE := thumb
+#switch to arm or thumb instruction set per function based on speed(dont restrict to only arm or thumb use both)
+LOCAL_CFLAGS += -mthumb-interwork
 
 #enable/disable optimization
 ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
-V7PLUSOPTIMIZATION ?= 1
+   LOCAL_CFLAGS += -munaligned-access
+   V7NEONOPTIMIZATION ?= 0
+else ifeq ($(TARGET_ARCH_ABI),arm64-v8a)
+#neon is a requirement for armv8 so just enable it
+   LOCAL_CFLAGS += -munaligned-access
+   LOCAL_ARM_NEON := true
 endif
 
 #armv7+ optimizations
-ifeq ($(V7PLUSOPTIMIZATION),1)
-#we dont need LOCAL_ARM_MODE := arm because armv7a has thumb2 that has varible length instructions
-LOCAL_ARM_MODE := thumb
-LOCAL_ARM_NEON := true
-else
-LOCAL_ARM_MODE := arm
+ifeq ($(V7NEONOPTIMIZATION),1)
+   LOCAL_ARM_NEON := true
 endif
-
-
 endif
 
 ifeq ($(TARGET_ARCH),x86)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -44,6 +44,47 @@ static retro_environment_t environ_cb = NULL;
 
 extern s9xcommand_t			keymap[1024];
 
+
+static void check_variables(void)
+{
+   bool reset_sfx = false;
+   struct retro_variable var;
+   var.key = "snes9x_next_overclock";
+   var.value = NULL;
+   
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 10.5e6;
+         reset_sfx = true;
+      }
+      else if (strcmp(var.value, "40MHz") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6;
+         reset_sfx = true;
+      }
+      else if (strcmp(var.value, "60MHz") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6;
+         reset_sfx = true;
+      }
+      else if (strcmp(var.value, "80MHz") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 80.5e6;
+         reset_sfx = true;
+      }
+      else if (strcmp(var.value, "100MHz") == 0)
+      {
+         Settings.SuperFXSpeedPerLine = 0.417 * 100.5e6;
+         reset_sfx = true;
+      }
+   }
+   
+   if (reset_sfx)
+   S9xResetSuperFX();
+}
+
 void *retro_get_memory_data(unsigned type)
 {
    uint8_t* data;
@@ -433,6 +474,8 @@ void retro_deinit(void)
 void retro_reset (void)
 {
    S9xSoftReset();
+   
+   check_variables();
 }
 
 static int16_t retro_mouse_state[2][2] = {{0}, {0}};
@@ -574,55 +617,12 @@ static void report_buttons (void)
 #endif
 }
 
-static void check_variables(void)
-{
-   bool reset_sfx = false;
-   struct retro_variable var;
-   var.key = "snes9x_next_overclock";
-   var.value = NULL;
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-   {
-      if (strcmp(var.value, "disabled") == 0)
-      {
-         Settings.SuperFXSpeedPerLine = 0.417 * 10.5e6;
-         reset_sfx = true;
-      }
-      else if (strcmp(var.value, "40MHz") == 0)
-      {
-         Settings.SuperFXSpeedPerLine = 0.417 * 40.5e6;
-         reset_sfx = true;
-      }
-      else if (strcmp(var.value, "60MHz") == 0)
-      {
-         Settings.SuperFXSpeedPerLine = 0.417 * 60.5e6;
-         reset_sfx = true;
-      }
-      else if (strcmp(var.value, "80MHz") == 0)
-      {
-         Settings.SuperFXSpeedPerLine = 0.417 * 80.5e6;
-         reset_sfx = true;
-      }
-      else if (strcmp(var.value, "100MHz") == 0)
-      {
-         Settings.SuperFXSpeedPerLine = 0.417 * 100.5e6;
-         reset_sfx = true;
-      }
-   }
-
-   if (reset_sfx)
-      S9xResetSuperFX();
-}
-
 void retro_run (void)
 {
    bool updated = false;
    poll_cb();
    report_buttons();
    S9xMainLoop();
-
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
-      check_variables();
 }
 
 size_t retro_serialize_size (void)


### PR DESCRIPTION
Configure new build architecture "armeabi-v7a-neon"(requires new libretro-build-android-mk.sh,also submitted to libretro-super)
(V7NEONOPTIMIZATION=1 is set when building for armeabi-v7a-neon)
Use thumb as default instruction set.(LOCAL_ARM_MODE := thumb)(on all arm versions)
Disable forced instruction set,use arm and thumb opcodes.(-mthumb-interwork)(on all arm versions)
Enable non 32bit aligned access on armv7.(-munaligned-access)

These changes should be applied to all cores,this makefile can be used as a template.