### PR TITLE
(GX) Rework the Load/Save state issue.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,7 +1,6 @@
 DEBUG=0
 HAVE_GRIFFIN=0
 STATIC_LINKING=0
-PREF_OPTIMIZATION=O3
 LAGFIX=1
 
 CORE_DIR := .
@@ -259,7 +258,6 @@ else ifeq ($(platform), ngc)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	CFLAGS += -DGEKKO -DHW_DOL -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST
 	STATIC_LINKING=1
-	PREF_OPTIMIZATION=O2
 
 # Nintendo Wii
 else ifeq ($(platform), wii)
@@ -269,7 +267,6 @@ else ifeq ($(platform), wii)
 	AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
 	CFLAGS += -DGEKKO -DHW_RVL -mrvl -mcpu=750 -meabi -mhard-float -D__ppc__ -DMSB_FIRST
 	STATIC_LINKING=1
-	PREF_OPTIMIZATION=O2
 
 # ARM
 else ifneq (,$(findstring armv,$(platform)))
@@ -334,7 +331,7 @@ endif
 ifeq ($(DEBUG), 1)
 	CFLAGS += -O0 -g
 else
-	CFLAGS += -$(PREF_OPTIMIZATION) -DNDEBUG
+	CFLAGS += -O3 -DNDEBUG
 endif
 
 

--- a/src/apu.c
+++ b/src/apu.c
@@ -187,6 +187,14 @@
 #include "snapshot.h"
 #include "display.h"
 
+/* The Wii version sometimes has issues with memcpy fnt when optimized, 
+   so we remove optimzations from save/load state fnts using this macro */
+#ifdef GEKKO
+#define NO_OPTIMIZE __attribute__((optimize("O0")))
+#else
+#define NO_OPTIMIZE
+#endif
+
 /***********************************************************************************
 	SPC DSP
 ***********************************************************************************/
@@ -1256,7 +1264,7 @@ static void spc_copier_extra(spc_state_copy_t * copier)
 
 /* Saves/loads exact emulator state */
 
-static void dsp_copy_state( unsigned char** io, dsp_copy_func_t copy )
+static void NO_OPTIMIZE dsp_copy_state( unsigned char** io, dsp_copy_func_t copy )
 {
 	int i, j;
 
@@ -2991,7 +2999,7 @@ static void spc_soft_reset (void)
 }
 
 #if !SPC_NO_COPY_STATE_FUNCS
-void spc_copy_state( unsigned char** io, dsp_copy_func_t copy )
+void NO_OPTIMIZE spc_copy_state( unsigned char** io, dsp_copy_func_t copy )
 {
 	int i;
 	spc_state_copy_t copier;
@@ -3599,13 +3607,13 @@ void S9xSoftResetAPU (void)
 	resampler_clear();
 }
 
-static void from_apu_to_state (uint8 **buf, void *var, size_t size)
+static void NO_OPTIMIZE from_apu_to_state (uint8 **buf, void *var, size_t size)
 {
 	memcpy(*buf, var, size);
 	*buf += size;
 }
 
-static void to_apu_from_state (uint8 **buf, void *var, size_t size)
+static void NO_OPTIMIZE to_apu_from_state (uint8 **buf, void *var, size_t size)
 {
 	memcpy(var, *buf, size);
 	*buf += size;


### PR DESCRIPTION
Disable optimization for the state functions only. Restoring the O3 default optimization for the rest. A better solution as it also handles some trouble games like FF3.